### PR TITLE
 	Fixed a bug in test

### DIFF
--- a/test/AboutYou/AboutYouTests.js
+++ b/test/AboutYou/AboutYouTests.js
@@ -165,7 +165,7 @@ describe('AboutYou', function () {
             criteria.setLimit(limit, offset);
 
             expect(criteria._result).to.eql({
-                'limit': 200,
+                'limit': Math.max(200, limit),
                 'offset': offset
             });
             done();


### PR DESCRIPTION
if the randomly generated limit value set by the setLimit function is less than 200, then the test should not fail